### PR TITLE
Red ViewScene Part2

### DIFF
--- a/src/Interface/Modules/Render/ES/AssetBootstrap.cc
+++ b/src/Interface/Modules/Render/ES/AssetBootstrap.cc
@@ -50,14 +50,14 @@ public:
     // A cached entity so that our VBOs and IBOs will not get garbage collected.
     uint64_t cachedEntity = 0;
     cachedEntity = gen::StaticObjRefID::getNewObjectID(core);
-    if (std::shared_ptr<ren::GeomMan> geomMan = gm.lock()) {
-        // Load geometry and associated vertex and fragment shaders.
-        geomMan->loadGeometry(core, cachedEntity, "Assets/arrow.geom");
-        geomMan->loadGeometry(core, cachedEntity, "Assets/sphere.geom");
+    if (std::shared_ptr<ren::GeomMan> geomMan = gm.lock())
+    {
+      // Load geometry and associated vertex and fragment shaders.
+      geomMan->loadGeometry(core, cachedEntity, "Assets/arrow.geom");
     }
-    if (std::shared_ptr<ren::ShaderMan> shaderMan = sm.lock()) {
+    if (std::shared_ptr<ren::ShaderMan> shaderMan = sm.lock())
+    {
         // Load shader we will use with the coordinate axes.
-      shaderMan->loadVertexAndFragmentShader(core, cachedEntity, "Shaders/DirPhong");
       shaderMan->loadVertexAndFragmentShader(core, cachedEntity, "Shaders/OrientationGlyph");
     }
 

--- a/src/Interface/Modules/Render/ES/Core.cc
+++ b/src/Interface/Modules/Render/ES/Core.cc
@@ -151,7 +151,19 @@ void ESCore::execute(double currentTime, double constantFrameTime)
   // Perform garbage collection if requested.
   if(runGC)
   {
-    runCompleteGC();
+    bool run = true;
+    for(auto& comp : mComponents)
+      if(comp.second->getNumComponents() > 0)
+      {
+        if(mComponentIDNameMap.find(comp.first) != mComponentIDNameMap.end() &&
+           mComponentIDNameMap.at(comp.first) == "ren:GeomPromise")
+        {
+          run = false;
+          break;
+        }
+      }
+    if(run) runCompleteGC();
+    else std::cout << "abourted GC\n";
     runGC = false;
   }
 

--- a/src/Interface/Modules/Render/ES/SRInterface.cc
+++ b/src/Interface/Modules/Render/ES/SRInterface.cc
@@ -834,6 +834,9 @@ namespace SCIRun {
 
       DEBUG_LOG_LINE_INFO
 
+      if(!mCore.getStaticComponent<ren::StaticVBOMan>() ||
+         !mCore.getStaticComponent<ren::StaticIBOMan>()) return;
+
       std::weak_ptr<ren::VBOMan> vm = mCore.getStaticComponent<ren::StaticVBOMan>()->instance_;
       std::weak_ptr<ren::IBOMan> im = mCore.getStaticComponent<ren::StaticIBOMan>()->instance_;
       if (std::shared_ptr<ren::VBOMan> vboMan = vm.lock())


### PR DESCRIPTION
Fixed the issue causing the new red viewScene by preventing the garbage collector from running when there are unfulfilled geometry promises. Also fixes a segfault in SRInterface and removes unused assets from assetbootstrap.
